### PR TITLE
Fix options not being passed to npm-http-server

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,10 +10,10 @@ const app = express()
 app.disable('x-powered-by')
 app.use(cors())
 app.use(express.static('public', { maxAge: 60000 }))
-app.use(createRequestHandler(
-  registryURL,
-  bowerBundle
-))
+app.use(createRequestHandler({
+  registryURL: registryURL,
+  bowerBundle: bowerBundle
+}))
 
 app.listen(port, function () {
   console.log('Server started on port %s, Ctrl+C to quit', port)


### PR DESCRIPTION
`npm-http-server` expects options as a hash, but they were being passed as arguments. This did not affect npmcdn.com because the defaults were being used anyway, but I ran into it when setting it up internally at my company. `#TrolledByMJ` again